### PR TITLE
Replace U+00A0 NO-BREAK SPACE with normal spaces

### DIFF
--- a/buzz.js
+++ b/buzz.js
@@ -602,16 +602,16 @@ var buzz = {
     isSupported: function() {
         return !!this.el.canPlayType;
     },
-    isOGGSupported: function() {
+    isOGGSupported: function() {
         return !!this.el.canPlayType && this.el.canPlayType( 'audio/ogg; codecs="vorbis"' );
     },
-    isWAVSupported: function() {
+    isWAVSupported: function() {
         return !!this.el.canPlayType && this.el.canPlayType( 'audio/wav; codecs="1"' );
     },
-    isMP3Supported: function() {
+    isMP3Supported: function() {
         return !!this.el.canPlayType && this.el.canPlayType( 'audio/mpeg;' );
     },
-    isAACSupported: function() {
+    isAACSupported: function() {
         return !!this.el.canPlayType && ( this.el.canPlayType( 'audio/x-m4a;' ) || this.el.canPlayType( 'audio/aac;' ) );
     },
     toTimer: function( time, withHours ) {


### PR DESCRIPTION
NBSP isn't wrong per se, but if the character encoding is detected
incorrectly, this will appear as some garbage that breaks the script.
