### PR TITLE
Fix adding sound to group

### DIFF
--- a/buzz.js
+++ b/buzz.js
@@ -552,9 +552,7 @@ var buzz = {
         this.add = function( soundArray ) {
             var soundArray = argsToArray( soundArray, arguments );
             for( var a = 0; a < soundArray.length; a++ ) {
-                for( var i = 0; i < sounds.length; i++ ) {
-                    sounds.push( soundArray[ a ] );
-                }
+                sounds.push( soundArray[ a ] );
             }
         }
 


### PR DESCRIPTION
Adding sounds to group did not work correctly. Only as many sounds as the group already had would be added to the group (no sounds if the group didn't have any sounds previously).
