### PR TITLE
Now possible to write classes extending buzz.sound

### DIFF
--- a/buzz.js
+++ b/buzz.js
@@ -590,7 +590,7 @@ var buzz = {
         }
 
         // init
-        if ( supported ) {
+        if ( supported && src ) {
           
             for(var i in buzz.defaults ) {
               if(buzz.defaults.hasOwnProperty(i)) {


### PR DESCRIPTION
The code below triggered the error. All I needed to do was to change the constructor of buzz.sound so that I could instantiate buzz.sound without arguments

``` js
var MySoundClass;
MySoundClass.prototype = new buzz.sound();
MySoundClass.prototype.constructor = MySoundClass;
function MySoundClass(src, options) {
    buzz.sound.call(this, src, options);
}
```
