### PR TITLE
iframe support, AMD and CommonJS support 

### DIFF
--- a/buzz.js
+++ b/buzz.js
@@ -32,7 +32,7 @@
     } else if (typeof context.define === 'function' && context.define.amd) {
         define(name, [], factory);
     } else {
-        context[name] = factory;
+        context[name] = factory();
     }
 })('buzz', this, function(){
 


### PR DESCRIPTION
https://github.com/dexteryy/buzz/commit/eaecfd272e19415a30fce91aa05b7dffd4f24bf2

With new option `document`, we can create  `<audio>` element in an iframe's context, then we can truly destory useless audio through removing or reloading the iframe. This is useful for avoiding some crash bug in Chrome. 

https://github.com/dexteryy/buzz/commit/248d07b724d7eb23e6db944b7d46aab84ed48888

We can use buzz.js as an AMD module with [require.js](http://requirejs.org/) or [oz.js](http://ozjs.org), without any configuration or hacks.
