### PR TITLE
Add channel support

### DIFF
--- a/src/buzz.js
+++ b/src/buzz.js
@@ -20,6 +20,7 @@
     var buzz = {
         defaults: {
             autoplay: false,
+            channel: '',
             duration: 5000,
             formats: [],
             loop: false,
@@ -279,6 +280,26 @@
                 return this.sound.playbackRate;
             };
 
+            this.setChannel = function (channel) {
+                if (!supported) {
+                    return this;
+                }
+
+                this.channel = channel;
+                this.sound.mozAudioChannelType = channel;
+
+                return this;
+            };
+
+            this.getChannel = function () {
+                if (!supported) {
+                    return this;
+                }
+
+                return this.channel;
+            };
+
+            
             this.getDuration = function () {
                 if (!supported) {
                     return null;
@@ -632,6 +653,10 @@
 
                 this.sound = doc.createElement('audio');
 
+                if (options.channel) {
+                    this.setChannel(options.channel);
+                }
+                
                 if (src instanceof Array) {
                     for (var j in src) {
                         if (src.hasOwnProperty(j)) {

--- a/test/spec/buzz-sound-spec.js
+++ b/test/spec/buzz-sound-spec.js
@@ -42,6 +42,11 @@ describe('buzz.sound', function() {
 				expect(sound).toThrow(e);
 			}
 		});
+		
+		it('should set the channel when passed as an option', function() {
+            sound = new buzz.sound(fixture, { formats: formats, channel: 'alarm' });
+			expect(sound.getChannel()).toBe('alarm');
+		});
 	});
 	
 	describe('audio control', function() {


### PR DESCRIPTION
In Firefox OS one can define channels on HTML5 audio objects.
More information: https://wiki.mozilla.org/WebAPI/AudioChannels

An how to add these channels can be found in that Google Group (Didn't find a nicer howto): 
https://groups.google.com/forum/?fromgroups=#!topic/mozilla.dev.gaia/HyAlHdFdX68

This PR adds the ability to define a channel on create.
