### PR TITLE
options.xxx=false overwrite bugfix

### DIFF
--- a/src/buzz.js
+++ b/src/buzz.js
@@ -626,7 +626,8 @@
 
                 for (var i in buzz.defaults) {
                     if (buzz.defaults.hasOwnProperty(i)) {
-                        options[i] = options[i] || buzz.defaults[i];
+                        if (options[i] === undefined)
+                            options[i] = buzz.defaults[i];
                     }
                 }
 

--- a/test/spec/buzz-sound-spec.js
+++ b/test/spec/buzz-sound-spec.js
@@ -19,13 +19,14 @@ describe('buzz.sound', function() {
 		}, 'song get started', 1000);
 	};
 	
+
 	describe('initializing a sound', function() {
 		var sound;
 		
 		afterEach(function() {
 			this.addMatchers(matchers);
 		});
-		
+	
 		it('should start playing a sound with volume 10', function() {
 			sound = new buzz.sound(fixture, { 
 				formats: formats,
@@ -41,6 +42,15 @@ describe('buzz.sound', function() {
 			} catch(e) {
 				expect(sound).toThrow(e);
 			}
+		});
+
+		it('should not preload when the preload option==false', function() {
+			sound = new buzz.sound(fixture, { formats: formats, preload:false });
+			sound.bind('loadeddata', function(e){
+				e.stopPropagation();
+    			e.preventDefault();
+    			expect('ASYNC FAILURE IN should not preload when the preload option==false').toBe(false);
+				});
 		});
 	});
 	


### PR DESCRIPTION
Bugfix for accidentially overwriting sound constructor options that are set to false.

Currently if you create a new sound with 

```
var buzz_sound = new buzz.sound(sound_path, {
                formats: ['ogg', 'mp3'],
                loop: true,
                preload: false
            });
```

The sound file will be preloaded regardless. 
The extra test in the test suite will verify the bug. After pulling changes into src/buzz.js the bug is fixed.
