### PR TITLE
Included a "scripts" array to component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,6 +6,9 @@
   "author": "Jay Salvat",
   "license": "MIT",
   "main": "dist/buzz.js",
+  "scripts":[
+    "dist/buzz.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:jaysalvat/buzz.git"


### PR DESCRIPTION
Repository is not being loaded remotely when using the cli command "component install" followed by "component build" when adding buzz as a dependency. This could be because the main file has not been explicitly defined in a "scripts" array.
