### PR TITLE
Qualify window.document because some environments (e.g. node-webkit) wil...

### DIFF
--- a/src/buzz.js
+++ b/src/buzz.js
@@ -26,7 +26,7 @@
             placeholder: '--',
             preload: 'metadata',
             volume: 80,
-            document: document // iframe support
+            document: window.document // iframe support
         },
         types: {
             'mp3': 'audio/mpeg',


### PR DESCRIPTION
...l not have window as global
