### PR TITLE
Don't create the AudioContext unless it is needed

### DIFF
--- a/src/buzz.js
+++ b/src/buzz.js
@@ -25,7 +25,6 @@
     var AudioContext = window.AudioContext || window.webkitAudioContext;
 
     var buzz = {
-        audioCtx: window.AudioContext ? new AudioContext() : null,
         defaults: {
             autoplay: false,
             duration: 5000,
@@ -46,6 +45,19 @@
         },
         sounds: [],
         el: document.createElement('audio'),
+        
+        getAudioContext: function() {
+            if (this.audioCtx === undefined) {
+                try {
+                    this.audioCtx = AudioContext ? new AudioContext() : null;
+                } catch (e) {
+                    // There is a limit to how many contexts you can have, so fall back in case of errors constructing it
+                    this.audioCtx = null;
+                }
+            }
+          
+            return this.audioCtx;
+        },
 
         sound: function (src, options) {
             options = options || {};
@@ -654,9 +666,12 @@
                 this.sound = doc.createElement('audio');
                 
                 // Use web audio if possible to improve performance.
-                if (options.webAudioApi && buzz.audioCtx) {
-                    this.source = buzz.audioCtx.createMediaElementSource(this.sound);
-                    this.source.connect(buzz.audioCtx.destination);
+                if (options.webAudioApi) {
+                    var audioCtx = buzz.getAudioContext();
+                    if (audioCtx) {
+                      this.source = audioCtx.createMediaElementSource(this.sound);
+                      this.source.connect(audioCtx.destination);
+                    }
                 }
 
                 if (src instanceof Array) {


### PR DESCRIPTION
We ran into the following error when many tabs are opened:

Uncaught SyntaxError: Failed to construct 'AudioContext': number of hardware contexts reached maximum (6).

This is caused by the AudioContext always being created, although "webAudioApi" is not enabled.

This PR lazily creates the context. In addition it also catches any errors, so it falls back to the usual way of playing if the limit has been reached.