### PR TITLE
Add crossOrigin support to allow CORS

### DIFF
--- a/src/buzz.js
+++ b/src/buzz.js
@@ -27,6 +27,7 @@
     var buzz = {
         defaults: {
             autoplay: false,
+            crossOrigin: false,
             duration: 5000,
             formats: [],
             loop: false,
@@ -663,6 +664,11 @@
                 }
 
                 this.sound = doc.createElement('audio');
+                
+                // Shoud we set crossOrigin?
+                if (options.crossOrigin !== null) {
+                    this.sound.crossOrigin = options.crossOrigin;
+                }
                 
                 // Use web audio if possible to improve performance.
                 if (options.webAudioApi) {

--- a/src/buzz.js
+++ b/src/buzz.js
@@ -27,7 +27,7 @@
     var buzz = {
         defaults: {
             autoplay: false,
-            crossOrigin: false,
+            crossOrigin: null,
             duration: 5000,
             formats: [],
             loop: false,


### PR DESCRIPTION
When loading audio files from another domain in SSL, Chrome will not load the file with error "MediaElementAudioSource outputs zeroes due to CORS access restrictions". This patch adds the property required to make a proper CORS request. For this to work, the destination domain should have a proper "Access-Control-Allow-Origin" http header.