### PR TITLE
Promises exceptions suppressed in Chrome

### DIFF
--- a/src/buzz.js
+++ b/src/buzz.js
@@ -86,7 +86,7 @@
                     return this;
                 }
 
-                this.sound.play();
+                this.sound.play().catch(() => {});
 
                 return this;
             };
@@ -97,7 +97,7 @@
                 }
 
                 if (this.sound.paused) {
-                    this.sound.play();
+                    this.sound.play().catch(() => {});
                 } else {
                     this.sound.pause();
                 }

--- a/src/buzz.js
+++ b/src/buzz.js
@@ -86,7 +86,7 @@
                     return this;
                 }
 
-                this.sound.play().catch(() => {});
+                this.sound.play().catch(function () {});
 
                 return this;
             };
@@ -97,7 +97,7 @@
                 }
 
                 if (this.sound.paused) {
-                    this.sound.play().catch(() => {});
+                    this.sound.play().catch(function () {});
                 } else {
                     this.sound.pause();
                 }


### PR DESCRIPTION
Current Chrome version throws a lot of exceptions on pages with heavy use of sounds:
`Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22`
As this library uses events for asynchronous handling, it should be okay to just ignore promise exceptions.